### PR TITLE
Sec: Pin github actions to sha's

### DIFF
--- a/.github/workflows/codeql-analysis-default.yml
+++ b/.github/workflows/codeql-analysis-default.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Install nodejs
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '>=20'
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 # v3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config-default.yml
@@ -42,6 +42,6 @@ jobs:
         queries: security-extended,security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency_enforcement.yml
+++ b/.github/workflows/dependency_enforcement.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: employ-self-hosted
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@67d4f4bd7a9b17a0db54d2a7519187c65e339de8 # v4
         with:
           fail-on-severity: critical
           fail-on-scopes: runtime, development


### PR DESCRIPTION
Why do we need this change?
=======================
tj-actions recently had an issue with their setup that caused exposure of info, so in best practice alignment pin actions to particular sha's for security

What effects does this change have?
=======================
Pin's actions to sha's excluding our internal ones.